### PR TITLE
Fix for R16B01

### DIFF
--- a/test/bench_encode_records.erl
+++ b/test/bench_encode_records.erl
@@ -8,7 +8,7 @@ data() ->
 	    age = 116,
 	    adress = <<"ИзбаНаОкорочках, Болото, Лес, Россия">>,
 	    phones = [<<"666-66-66">>],
-	    email = baba_yaga@les.ru
+	    email = 'baba_yaga@les.ru'
 	   }.
 
 test() ->


### PR DESCRIPTION
Failed at R16B01 like this:

```
==> jsonx (eunit)
test/bench_encode_records.erl:11: syntax error before: '.'
test/bench_encode_records.erl:27: function data/0 undefined
```
