### PR TITLE
Decode escaped solidus

### DIFF
--- a/c_src/jsonx_str.h
+++ b/c_src/jsonx_str.h
@@ -170,6 +170,7 @@ check_with_unescape_jstr(unsigned char *str, unsigned char **endstr, unsigned ch
       case 'f' : {src++; *dst++ = 12U; continue;}
       case 'r' : {src++; *dst++ = 13U; continue;}
       case '"' : {src++; *dst++ = 34U; continue;}
+      case '/' : {src++; *dst++ = 47U; continue;}
       case '\\': {src++; *dst++ = 92U; continue;}
       case 'u': {
 	unsigned hval;

--- a/test/str_tests.erl
+++ b/test/str_tests.erl
@@ -49,6 +49,8 @@ decstr1_test() ->
     <<"...">> = jsonx:decode(<<"\"...\"">>).
 decstr2_test() ->
     <<192, 128, 224, 128, 128, 240, 128, 128, 128>> = jsonx:decode(<<34,192,128,224,128,128,240,128,128,128,34>>).
+decstr3_test() ->
+    <<"/">> = jsonx:decode(<<"\"\\/\"">>).
 decstre0_test() ->
     {error,invalid_string,0} = jsonx:decode(<<34,192,34>>).
 decstre01_test() ->


### PR DESCRIPTION
Some encoders do that strange thing, but still it is valid json.
