### PR TITLE
Ignore null member encoding

### DIFF
--- a/c_src/encoder.c
+++ b/c_src/encoder.c
@@ -278,12 +278,15 @@ match_record(ErlNifEnv* env, int arity, const ERL_NIF_TERM *tuple, State *st){
       unsigned bin_size = 0;
       b_putc('{', st);
       for(k = 0; k < records[i].arity; k++){
-	EncField field = fields[fds_offset + k];
-	bin_size += field.size;
+
+        if(tuple[k+1] != st->priv->am_null){
+          EncField field = fields[fds_offset + k];
+          bin_size += field.size;
 	//FIXME {
-	b_puts(field.size, st->records->bin.data + field.offset, st);
-	if(!match_term(env, tuple[k+1], st))
-	  return 0;
+          b_puts(field.size, st->records->bin.data + field.offset, st);
+          if(!match_term(env, tuple[k+1], st))
+            return 0;
+        }
       }
       b_putc('}', st);
       return 1;

--- a/c_src/encoder.c
+++ b/c_src/encoder.c
@@ -267,6 +267,21 @@ match_json(ErlNifEnv* env, ERL_NIF_TERM term, State *st){
 }
 
 static inline int
+enc_should_be_ignored(ErlNifEnv* env, ERL_NIF_TERM atom, const EncEntry* entry){
+  if(!enif_is_atom(env, atom)){
+    return 0;
+  }
+  unsigned i;
+  for(i=0; i<entry->ignored_len; ++i){
+    if(enif_is_identical(atom, entry->ignored[i])){
+      return 1;
+    }
+  }
+  return 0;
+}
+
+
+static inline int
 match_record(ErlNifEnv* env, int arity, const ERL_NIF_TERM *tuple, State *st){
 
   EncRecord *records = enc_records_base(st->records);
@@ -279,7 +294,7 @@ match_record(ErlNifEnv* env, int arity, const ERL_NIF_TERM *tuple, State *st){
       b_putc('{', st);
       for(k = 0; k < records[i].arity; k++){
 
-        if(tuple[k+1] != st->priv->am_null){
+        if(!enc_should_be_ignored(env, tuple[k+1], st->records)){
           EncField field = fields[fds_offset + k];
           bin_size += field.size;
 	//FIXME {

--- a/c_src/jsonx.h
+++ b/c_src/jsonx.h
@@ -72,6 +72,8 @@ typedef struct{
   ErlNifBinary bin;
   unsigned records_cnt;
   unsigned fields_cnt;
+  ERL_NIF_TERM* ignored;
+  unsigned ignored_len;
 }EncEntry;
 
 static inline EncRecord*

--- a/examples/records_examples.erl
+++ b/examples/records_examples.erl
@@ -8,6 +8,10 @@ encoder1() ->
     jsonx:encoder([{person,   record_info(fields, person)},
                    {person2,  record_info(fields, person2)} ]).
 
+encoder1_ignore() ->
+    jsonx:encoder([{person,   record_info(fields, person)},
+                   {person2,  record_info(fields, person2)} ], [{ignore, [null]}]).
+
 decoder1() ->
     jsonx:decoder([{person,   record_info(fields, person)},
                    {person2,  record_info(fields, person2)}]).

--- a/src/jsonx.erl
+++ b/src/jsonx.erl
@@ -30,10 +30,13 @@
 %%      </ul>
 
 -module(jsonx).
--export([encode/1, decode/1, decode/2, encoder/1, decoder/1, decoder/2]).
+-export([encode/1, decode/1, decode/2,
+         encoder/1, encoder/2, decoder/1, decoder/2]).
 -on_load(init/0).
 -define(LIBNAME, jsonx).
 -define(APPNAME, jsonx).
+
+-include_lib("eunit/include/eunit.hrl").
 
 %% =================
 %% API Encoding JSON
@@ -51,8 +54,17 @@ encode(JSON_TERM)->
       RECORDS_DESC :: [{tag, [names]}],
       ENCODER      :: function().
 encoder(Records_desc) ->
+    encoder(Records_desc, []).
+
+%%@doc Build a JSON encoder.
+-spec encoder(RECORDS_DESC, OPTIONS) -> ENCODER when
+      RECORDS_DESC :: [{tag, [names]}],
+      OPTIONS      :: [{ignore, [atom()]}],
+      ENCODER      :: function().
+encoder(Records_desc, Options) ->
     {Rcnt, Fcnt, Binsz, Records, Fields, Bin} = prepare_enc_desc(Records_desc),
-    Resource = make_encoder_resource(Rcnt, Fcnt, Records, Fields, Binsz, Bin),
+    Ignored = proplists:get_value(ignore, Options, []),
+    Resource = make_encoder_resource(Rcnt, Fcnt, Records, Fields, Binsz, Bin, Ignored),
     fun(JSON_TERM) -> encode_res(JSON_TERM, Resource) end.
 
 %% ==================
@@ -116,7 +128,7 @@ decode_opt(_JSON, _FORMAT) ->
 decode_res(_JSON_TERM, _FORMAT, _RESOURCE, _STRICT_FLAG) ->
     not_loaded(?LINE).
 
-make_encoder_resource(_Rcnt, _Fcnt, _Records, _Fields, _Binsz, _Bin) ->
+make_encoder_resource(_Rcnt, _Fcnt, _Records, _Fields, _Binsz, _Bin, _Ignored) ->
     not_loaded(?LINE).
 
 make_decoder_resource(_RecCnt, _UKeyCnt, _KeyCnt, _UKeys, _Keys, _Records3) ->

--- a/test/encode_records_test.erl
+++ b/test/encode_records_test.erl
@@ -20,3 +20,10 @@ encrec1_test() ->
 encrec2_test() ->
     F = jsonx:encoder([ {rec, record_info(fields, rec)} ]),
     <<"{\"a\": \"x\",\"b\": {\"a\": {\"a\": \"x\",\"b\": \"y\"},\"b\": \"w\"}}">> = F({rec, x, {rec, {rec, x, y}, w}}).
+
+
+
+encrec3_test() ->
+    %%F = jsonx:encoder([ {spam, [a, b, c]} ], [{ignore,null}]),
+    F = jsonx:encoder([ {spam, [a, b, c]} ]),
+    <<"{}">> = F({spam, null, null, null}). 

--- a/test/encode_records_test.erl
+++ b/test/encode_records_test.erl
@@ -25,5 +25,6 @@ encrec2_test() ->
 
 encrec3_test() ->
     %%F = jsonx:encoder([ {spam, [a, b, c]} ], [{ignore,null}]),
-    F = jsonx:encoder([ {spam, [a, b, c]} ]),
-    <<"{}">> = F({spam, null, null, null}). 
+    F = jsonx:encoder([ {spam, [a, b, c]} ], [{ignore, [null, undefined]}]),
+    <<"{}">> = F({spam, null, null, null}),
+    <<"{\"a\": \"nall\"}">> = F({spam, nall, null, undefined}).


### PR DESCRIPTION
Add option to `encoder/2`, which enables ignoring `null` or `undefined` atoms to make small output json.

``` erlang
  Encoder = jsonx:encoder([{r0, record_info(r0)}], [{ignore, [null]}]),
  <<"{}">> = Encoder({r0, null, null, null}).
```

Of course this encoding is irreversible, but sometimes size matters - the record can be rebuilt if json schema is  known, or record name is included inside the object.

``` erlang
  [{<<"record_name">>, <<"r0">>}] = jsonx:decode(<<"{\"record_name\":\"r0\"}">>),
  {r0, null, null, null} = rebuild_r0([{<<"record_name">>, <<"r0">>}], null).
```
