### PR TITLE
Fix nif to avoid segfault on upgrade

### DIFF
--- a/c_src/jsonx.c
+++ b/c_src/jsonx.c
@@ -62,10 +62,12 @@ reload(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info){
 
 static int
 upgrade(ErlNifEnv* env, void** priv_data, void** old_priv_data, ERL_NIF_TERM load_info){
+  *priv_data = *old_priv_data;
   return 0;
 }
 static void
 unload(ErlNifEnv* env, void* priv_data){
+  enif_free(priv_data);
   return;
 }
 

--- a/src/jsonx.erl
+++ b/src/jsonx.erl
@@ -231,7 +231,7 @@ init() ->
         Dir ->
             filename:join(Dir, ?LIBNAME)
     end,
-    erlang:load_nif(So, [[json, struct, proplist, eep18, no_match], [true, false, null],
+	ok = erlang:load_nif(So, [[json, struct, proplist, eep18, no_match], [true, false, null],
 			 [error, big_num, invalid_string, invalid_json, trailing_data, undefined_record]]).
 
 not_loaded(Line) ->


### PR DESCRIPTION
Hi
In development I use sync for hot code upgrade. Sometimes it reloads modules that not changed. And that behavior helped me to discover segmentation fault of jsonx.
The problem was in jsonx.c:64 as you can see. We should reinit or save our priv_data without changes. That is how I fixed this problem.
Also you can say that jsonx nif doesn't support hot code upgarade -> ERL_NIF_INIT(jsonx, nif_funcs, load, NULL, NULL, NULL);
Also I added enif_free to make unload more correct and match with ok in jsonx.erl:234 to exclude unexpected return values.
Thanks to @ten0s for help in debug.
I hope you like this fix.
