### PR TITLE
Add registered to .app.src

### DIFF
--- a/src/jsonx.app.src
+++ b/src/jsonx.app.src
@@ -4,6 +4,7 @@
  [
   {description, "JSON library for Erlang writen in C"},
   {vsn, "3.0"},
+  {registered, []},
   {applications, [
                   kernel,
                   stdlib


### PR DESCRIPTION
Without this systool can't use application for release generation.
