### PR TITLE
Remove include eunit.hrl

### DIFF
--- a/src/jsonx.erl
+++ b/src/jsonx.erl
@@ -36,8 +36,6 @@
 -define(LIBNAME, jsonx).
 -define(APPNAME, jsonx).
 
--include_lib("eunit/include/eunit.hrl").
-
 %% =================
 %% API Encoding JSON
 %% =================


### PR DESCRIPTION
It is not used also reltool add eunit as dependence.
