### PR TITLE
Dialyzer friendly errors

### DIFF
--- a/src/jsonx.erl
+++ b/src/jsonx.erl
@@ -233,4 +233,4 @@ init() ->
 			 [error, big_num, invalid_string, invalid_json, trailing_data, undefined_record]]).
 
 not_loaded(Line) ->
-    exit({not_loaded, [{module, ?MODULE}, {line, Line}]}).
+    erlang:nif_error({not_loaded, [{module, ?MODULE}, {line, Line}]}).


### PR DESCRIPTION
Changed not_loaded error to dialyzer friendly format.
http://www.erlang.org/doc/man/erlang.html#nif_error-1
