### PR TITLE
Option to decode fractional numbers to decimal

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ Mapping (JSON -> Erlang)
     {"this": "json"} :-> [{<<"this">>: <<"json">>}]           %% optional proplist
     {"this": "json"} :-> {struct, [{<<"this">>: <<"json">>}]} %% optional struct
     JSONObject       :-> #rec{...}                            %% decoder must be predefined
+    -1.123e12        :-> {1, 1123, 9}                         %% optional {number_format, decimal}
+    1.123e-6         :-> {0, 1123, -9}                        %% optional {number_format, decimal}
 
 Mapping (Erlang -> JSON)
 -----------------------

--- a/c_src/jsonx.c
+++ b/c_src/jsonx.c
@@ -50,6 +50,8 @@ load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info){
   if(!enif_make_existing_atom(env, "eep18",    &(pdata->am_eep18),    ERL_NIF_LATIN1)) return 1;
   if(!enif_make_existing_atom(env, "no_match", &(pdata->am_no_match), ERL_NIF_LATIN1)) return 1;
 
+  if(!enif_make_existing_atom(env, "decimal",    &(pdata->am_decimal),    ERL_NIF_LATIN1)) return 1;
+  if(!enif_make_existing_atom(env, "float",    &(pdata->am_float),    ERL_NIF_LATIN1)) return 1;
   *priv_data = (void*)pdata;
 
   return 0;
@@ -223,8 +225,8 @@ static ErlNifFunc
 nif_funcs[] = {
   {"encode1",     1, encode_nif},
   {"encode_res", 2, encode_nif}, // with resource
-  {"decode_opt", 2, decode_nif}, // with options
-  {"decode_res", 4, decode_nif}, // with options, resource and strict flag
+  {"decode_opt", 3, decode_nif}, // with options
+  {"decode_res", 5, decode_nif}, // with options, resource and strict flag
   {"make_encoder_resource", 7, make_encoder_resource_nif},
   {"make_decoder_resource", 6, make_decoder_resource_nif}
 };

--- a/c_src/jsonx.h
+++ b/c_src/jsonx.h
@@ -24,6 +24,9 @@ typedef struct{
   ERL_NIF_TERM am_eep18;
   ERL_NIF_TERM am_no_match;
 
+  ERL_NIF_TERM am_decimal;
+  ERL_NIF_TERM am_float;
+
   ErlNifResourceType* encoder_RSTYPE;
   ErlNifResourceType* decoder_RSTYPE;
 }PrivData;

--- a/src/jsonx.erl
+++ b/src/jsonx.erl
@@ -10,6 +10,7 @@
 %%       <li>false  -> atom false</li>
 %%       <li>string -> binary</li>
 %%       <li>number -> number</li>
+%%       <li>number -> {Sign, Value, Scale}, if non-integer and number_format is decimal (Sign = 0 for positive, 1 for negative)</li>
 %%       <li>array  -> list</li>
 %%       <li>object -> {PropList}, optional struct or proplist.</li>
 %%       <li>object -> #record{...} - decoder must be predefined</li>
@@ -79,7 +80,7 @@ decode(JSON) ->
 %%@doc Decode JSON to Erlang term with options.
 -spec decode(JSON, OPTIONS) -> JSON_TERM when
       JSON      :: binary(),
-      OPTIONS   :: [{format, struct|eep18|proplist}],
+      OPTIONS   :: [{format, struct|eep18|proplist} | {number_format, float|decimal}],
       JSON_TERM :: any().
 decode(JSON, Options) ->
     {Object, Float} = parse_format(Options),
@@ -97,7 +98,7 @@ decoder(Records_desc) ->
 %%@doc Build a JSON decoder with output undefined objects.
 -spec decoder(RECORDS_DESC, OPTIONS) -> DECODER when
       RECORDS_DESC :: [{tag, [names]}],
-      OPTIONS      :: [{format, struct|eep18|proplist}],
+      OPTIONS   :: [{format, struct|eep18|proplist} | {number_format, float|decimal}],
       DECODER      :: function().
 decoder(Records_desc, Options) ->
     {RecCnt, UKeyCnt, KeyCnt, UKeys, Keys, Records3} = prepare_for_dec(Records_desc),

--- a/test/num_tests.erl
+++ b/test/num_tests.erl
@@ -23,3 +23,19 @@ decnum00_test() ->
     0.0 = jsonx:decode(<<"0.0">>).
 decnum1_test() ->
     -0.0012 = jsonx:decode(<<"-1.2e-3">>).
+
+%% Test decode numerics to decimal
+decnum_decimal_integer_test() ->
+    123 = jsonx:decode(<<"123">>, [{number_format, decimal}]).
+decnum_decimal_zero_test() ->
+    {0, 0, -1} = jsonx:decode(<<"0.0">>, [{number_format, decimal}]).
+decnum_decimal_frac_exp_test() ->
+    {1,12,5} = jsonx:decode(<<"-1.2e6">>, [{number_format, decimal}]).
+decnum_decimal_frac_neg_exp_test() ->
+    {1,12,-4} = jsonx:decode(<<"-1.2e-3">>, [{number_format, decimal}]).
+decnum_decimal_frac_neg_exp_case_test() ->
+    {1,12,-4} = jsonx:decode(<<"-1.2E-3">>, [{number_format, decimal}]).
+decnum_decimal_frac_test() ->
+    {0,12,-1} = jsonx:decode(<<"1.2">>, [{number_format, decimal}]).
+decnum_decimal_exp_test() ->
+    {0,1,2} = jsonx:decode(<<"1e2">>, [{number_format, decimal}]).


### PR DESCRIPTION
New decode option `number_format` - when set to `decimal`, numbers with exponent or fraction are decoded to  erlang-decimal compatible tuple. For original behaviour omit this option or set it to `float`

```
{1,12,5} = jsonx:decode(<<"-1.2e6">>, [{number_format, decimal}]).
```
