### PR TITLE
Annotate utf-8 encoded file for backwards compatibility

### DIFF
--- a/test/bench_encode_records.erl
+++ b/test/bench_encode_records.erl
@@ -1,3 +1,4 @@
+%% -*- coding: utf-8 -*-
 -module(bench_encode_records).
 -export([test/0]).
 -record(person, {name, last_name, age, adress, phones, email}).


### PR DESCRIPTION
This makes it easier to use jsonx on an older Erlang/OTP platform.
